### PR TITLE
Fv 105 speichern einer Zählung

### DIFF
--- a/frontend/src/components/zaehlung/ZaehlungCard.vue
+++ b/frontend/src/components/zaehlung/ZaehlungCard.vue
@@ -186,7 +186,7 @@
 </template>
 
 <script setup lang="ts">
-import type FahrbeziehungDTO from "@/domain/dto/FahrbeziehungDTO";
+import type VerkehrsbeziehungDTO from "@/domain/dto/VerkehrsbeziehungDTO";
 import type UpdateStatusDTO from "@/domain/dto/UpdateStatusDTO";
 import type GeoPoint from "@/domain/GeoPoint";
 import type KnotenarmDTO from "@/types/zaehlung/KnotenarmDTO";
@@ -290,12 +290,12 @@ const showButtonAbschliessen = computed<boolean>(() => {
 
 // Liefert nur die Knotenarme zurueck, die ausgehenden Verkehr haben
 const knotenarmeWithOutgoingTraffic = computed<Array<KnotenarmDTO>>(() => {
-  const outgoingKnotenarmnummern = zaehlung.value.fahrbeziehungen.map(
-    (fahrbeziehung: FahrbeziehungDTO) => {
+  const outgoingKnotenarmnummern = zaehlung.value.verkehrsbeziehungen.map(
+    (verkehrsbeziehung: VerkehrsbeziehungDTO) => {
       if (zaehlung.value.kreisverkehr) {
-        return fahrbeziehung.knotenarm;
+        return verkehrsbeziehung.knotenarm;
       } else {
-        return fahrbeziehung.von;
+        return verkehrsbeziehung.von;
       }
     }
   );

--- a/frontend/src/components/zaehlung/ZaehlungDialog.vue
+++ b/frontend/src/components/zaehlung/ZaehlungDialog.vue
@@ -39,7 +39,7 @@
 </template>
 
 <script setup lang="ts">
-import type FahrbeziehungDTO from "@/domain/dto/FahrbeziehungDTO";
+import type VerkehrsbeziehungDTO from "@/domain/dto/VerkehrsbeziehungDTO";
 import type ZeitintervallDTO from "@/domain/dto/ZeitintervallDTO";
 import type { StartUhrzeitEndeUhrzeit } from "@/types/enum/Intervallnummern";
 import type KnotenarmDTO from "@/types/zaehlung/KnotenarmDTO";
@@ -115,25 +115,25 @@ function save(): void {
 /**
  * Bereitet die tiefen Kopie auf das speichern vor.
  * D.h. es werden die CSV-Files in Zeitintervall-Objekte umgewandelt
- * und den Fahrbeziehungen zu geordnet.
+ * und den Verkehrsbeziehungen zu geordnet.
  */
 function prepareForSaveZaehlung() {
-  const zeitintervalleProFahrbeziehung: Map<
+  const zeitintervalleProVerkehrsbeziehung: Map<
     string,
     Array<ZeitintervallDTO>
   > = new Map<string, Array<ZeitintervallDTO>>();
   zaehlung.value.knotenarme.forEach((arm: KnotenarmDTO) => {
     if (arm.filename && arm.filedata && arm.filedata.length > 0) {
-      transformCsvDataToFahrbeziehung(arm).forEach((value, key) => {
-        zeitintervalleProFahrbeziehung.set(key, value);
+      transformCsvDataToVerkehrsbeziehung(arm).forEach((value, key) => {
+        zeitintervalleProVerkehrsbeziehung.set(key, value);
       });
     }
   });
 
-  zaehlung.value.fahrbeziehungen.forEach((fz: FahrbeziehungDTO) => {
-    const key: string = getKeyOfFahrbeziehung(fz, zaehlung.value.kreisverkehr);
-    if (zeitintervalleProFahrbeziehung.has(key)) {
-      fz.zeitintervalle = zeitintervalleProFahrbeziehung.get(key)!;
+  zaehlung.value.verkehrsbeziehungen.forEach((fz: VerkehrsbeziehungDTO) => {
+    const key: string = getKeyOfVerkehrsbeziehung(fz, zaehlung.value.kreisverkehr);
+    if (zeitintervalleProVerkehrsbeziehung.has(key)) {
+      fz.zeitintervalle = zeitintervalleProVerkehrsbeziehung.get(key)!;
     }
     fz.isKreuzung = !zaehlung.value.kreisverkehr;
   });
@@ -143,10 +143,10 @@ function prepareForSaveZaehlung() {
  * Wandelt die am Knotenarm hinterlegten Daten aus der CSV in ein Array vom Typ ZeitintervallDTO um.
  * @param arm Knotenarm mit den Daten der csv
  */
-function transformCsvDataToFahrbeziehung(
+function transformCsvDataToVerkehrsbeziehung(
   arm: KnotenarmDTO
 ): Map<string, Array<ZeitintervallDTO>> {
-  const fahrbeziehungen: Map<string, Array<ZeitintervallDTO>> = new Map<
+  const verkehrsbeziehungen: Map<string, Array<ZeitintervallDTO>> = new Map<
     string,
     Array<ZeitintervallDTO>
   >();
@@ -205,13 +205,13 @@ function transformCsvDataToFahrbeziehung(
   });
 
   zeitinervalleProNach.forEach((value, key) => {
-    fahrbeziehungen.set(knotenarmVon + key, value);
+    verkehrsbeziehungen.set(knotenarmVon + key, value);
   });
-  return fahrbeziehungen;
+  return verkehrsbeziehungen;
 }
 
-function getKeyOfFahrbeziehung(
-  fz: FahrbeziehungDTO,
+function getKeyOfVerkehrsbeziehung(
+  fz: VerkehrsbeziehungDTO,
   isKreisverkehr: boolean
 ): string {
   let key = `${fz.knotenarm}`;

--- a/frontend/src/components/zaehlung/form/KnotenLageForm.vue
+++ b/frontend/src/components/zaehlung/form/KnotenLageForm.vue
@@ -132,8 +132,8 @@
           <v-data-table
             v-if="isNotKreisverkehr"
             density="compact"
-            :headers="fahrbeziehungHeader as Array<any>"
-            :items="allFahrbeziehungen"
+            :headers="verkehrsbeziehungHeader as Array<any>"
+            :items="allVerkehrsbeziehungen"
             item-key="id"
             :items-per-page="-1"
             hide-default-footer
@@ -146,7 +146,7 @@
 </template>
 
 <script setup lang="ts">
-import type FahrbeziehungDTO from "@/domain/dto/FahrbeziehungDTO";
+import type VerkehrsbeziehungDTO from "@/domain/dto/VerkehrsbeziehungDTO";
 import type GeoPoint from "@/domain/GeoPoint";
 import type KnotenarmDTO from "@/types/zaehlung/KnotenarmDTO";
 import type ZaehlungDTO from "@/types/zaehlung/ZaehlungDTO";
@@ -162,7 +162,7 @@ import { useSnackbarStore } from "@/store/SnackbarStore";
 import Status from "@/types/enum/Status";
 import Zaehlart from "@/types/enum/Zaehlart";
 import DefaultObjectCreator from "@/util/DefaultObjectCreator";
-import FahrbeziehungComparator from "@/util/FahrbeziehungComparator";
+import VerkehrsbeziehungComparator from "@/util/VerkehrsbeziehungComparator";
 import KnotenarmComparator from "@/util/KnotenarmComparator";
 
 interface Props {
@@ -226,15 +226,15 @@ const isZaehlungEditable = computed<boolean>(() => {
   return [Status.COUNTING, Status.CORRECTION].includes(zaehlung.value.status);
 });
 
-const allFahrbeziehungen = computed<Array<FahrbeziehungDTO>>(() =>
-  toArray(zaehlung.value.fahrbeziehungen).sort(
-    FahrbeziehungComparator.sortByActiveVonAndNach
+const allVerkehrsbeziehungen = computed<Array<VerkehrsbeziehungDTO>>(() =>
+  toArray(zaehlung.value.verkehrsbeziehungen).sort(
+      VerkehrsbeziehungComparator.sortByActiveVonAndNach
   )
 );
 
 const isNotKreisverkehr = computed<boolean>(() => !zaehlung.value.kreisverkehr);
 
-const fahrbeziehungHeader = [
+const verkehrsbeziehungHeader = [
   {
     title: "Von",
     align: "center",
@@ -370,34 +370,34 @@ function checkUploadedFiledata(
         }
       }
 
-      // Prüfung der Knotenarme in Zähldaten auf Übereinstimmung mit vorhandenen Fahrbeziehungen
+      // Prüfung der Knotenarme in Zähldaten auf Übereinstimmung mit vorhandenen Verkehrsbeziehungen
       if (csvLineIndex > 3) {
         const nach: string = splittedLine[1];
-        let fahrbeziehung: FahrbeziehungDTO | undefined;
+        let verkehrsbeziehung: VerkehrsbeziehungDTO | undefined;
         if (zaehlung.value.kreisverkehr) {
-          fahrbeziehung = zaehlung.value.fahrbeziehungen.find(
-            (fahrbeziehung) => {
+          verkehrsbeziehung = zaehlung.value.verkehrsbeziehungen.find(
+            (verkehrsbeziehung) => {
               return (
-                fahrbeziehung.knotenarm === armNummer &&
-                ((nach === "e" && fahrbeziehung.hinein) ||
-                  (nach === "v" && fahrbeziehung.vorbei) ||
-                  (nach === "a" && fahrbeziehung.heraus))
+                  verkehrsbeziehung.knotenarm === armNummer &&
+                ((nach === "e" && verkehrsbeziehung.hinein) ||
+                  (nach === "v" && verkehrsbeziehung.vorbei) ||
+                  (nach === "a" && verkehrsbeziehung.heraus))
               );
             }
           );
         } else {
           const nachArmNumber: number = parseInt(toString(nach.trim()));
-          fahrbeziehung = zaehlung.value.fahrbeziehungen.find(
-            (fahrbeziehung) => {
+          verkehrsbeziehung = zaehlung.value.verkehrsbeziehungen.find(
+            (verkehrsbeziehung) => {
               return (
-                armNummer === fahrbeziehung.von &&
-                nachArmNumber === fahrbeziehung.nach
+                armNummer === verkehrsbeziehung.von &&
+                nachArmNumber === verkehrsbeziehung.nach
               );
             }
           );
         }
-        if (isNil(fahrbeziehung)) {
-          return `Für die Zähldaten in Zeile ${csvLineNumber} ist keine Fahrbeziehung existent oder aktiv.\nWar: ${splittedLine}`;
+        if (isNil(verkehrsbeziehung)) {
+          return `Für die Zähldaten in Zeile ${csvLineNumber} ist keine Verkehrsbeziehung existent oder aktiv.\nWar: ${splittedLine}`;
         }
       }
 

--- a/frontend/src/components/zaehlung/form/KnotenLageForm.vue
+++ b/frontend/src/components/zaehlung/form/KnotenLageForm.vue
@@ -384,7 +384,7 @@ function checkUploadedFiledata(
           splittedLine
         );
       } else {
-        invalidityReason = checkFahrbeziehungData(
+        invalidityReason = checkVerkehrsbeziehungData(
           csvLineIndex,
           armNummer,
           splittedLine
@@ -424,23 +424,23 @@ function buildExpectedMetaData(armNummer: number): string {
 }
 
 /**
- * Prüfung der Knotenarme in Zähldaten auf Übereinstimmung mit vorhandenen Fahrbeziehungen.
+ * Prüfung der Knotenarme in Zähldaten auf Übereinstimmung mit vorhandenen Verkehrsbeziehungen.
  *
  * @param csvLineIndex aktueller Zeilenindex
  * @param armNummer Nummer des aktuellen Knotenarms
  * @param splittedLine Array der Zeilenspalten
  * @return Grund der Invalidität
  */
-function checkFahrbeziehungData(
+function checkVerkehrsbeziehungData(
   csvLineIndex: number,
   armNummer: number,
   splittedLine: Array<string>
 ): string {
   if (csvLineIndex > 3) {
     const nach: string = splittedLine[1];
-    let fahrbeziehung: VerkehrsbeziehungDTO | undefined;
+    let verkehrsbeziehung: VerkehrsbeziehungDTO | undefined;
     if (zaehlung.value.kreisverkehr) {
-      fahrbeziehung = zaehlung.value.verkehrsbeziehungen.find((verkehrsbeziehung) => {
+      verkehrsbeziehung = zaehlung.value.verkehrsbeziehungen.find((verkehrsbeziehung) => {
         return (
             verkehrsbeziehung.knotenarm === armNummer &&
           ((nach === "e" && verkehrsbeziehung.hinein) ||
@@ -450,15 +450,15 @@ function checkFahrbeziehungData(
       });
     } else {
       const nachArmNumber: number = parseInt(toString(nach.trim()));
-      fahrbeziehung = zaehlung.value.verkehrsbeziehungen.find((verkehrsbeziehung) => {
+      verkehrsbeziehung = zaehlung.value.verkehrsbeziehungen.find((verkehrsbeziehung) => {
         return (
           armNummer === verkehrsbeziehung.von &&
-          nachArmNumber === fahrbeziehung.nach
+          nachArmNumber === verkehrsbeziehung.nach
         );
       });
     }
-    if (isNil(fahrbeziehung)) {
-      return `Für die Zähldaten in Zeile ${csvLineIndex + 1} ist keine Fahrbeziehung existent oder aktiv.\nWar: ${splittedLine}`;
+    if (isNil(verkehrsbeziehung)) {
+      return `Für die Zähldaten in Zeile ${csvLineIndex + 1} ist keine Verkehrsbeziehung existent oder aktiv.\nWar: ${splittedLine}`;
     }
   }
 

--- a/frontend/src/domain/dto/VerkehrsbeziehungDTO.ts
+++ b/frontend/src/domain/dto/VerkehrsbeziehungDTO.ts
@@ -2,7 +2,7 @@ import type HochrechnungsfaktorDTO from "@/domain/dto/HochrechnungsfaktorDTO";
 import type ZeitintervallDTO from "@/domain/dto/ZeitintervallDTO";
 import type BaseEntity from "@/types/common/BaseEntity";
 
-export default interface FahrbeziehungDTO extends BaseEntity {
+export default interface VerkehrsbeziehungDTO extends BaseEntity {
   // Kreuzung
   von: number;
   nach: number;

--- a/frontend/src/store/ZaehlungStore.ts
+++ b/frontend/src/store/ZaehlungStore.ts
@@ -1,4 +1,4 @@
-import type FahrbeziehungDTO from "@/domain/dto/FahrbeziehungDTO";
+import type VerkehrsbeziehungDTO from "@/domain/dto/VerkehrsbeziehungDTO";
 import type KnotenarmDTO from "@/types/zaehlung/KnotenarmDTO";
 import type ZaehlungDTO from "@/types/zaehlung/ZaehlungDTO";
 
@@ -29,8 +29,8 @@ export const useZaehlungStore = defineStore("zaehlungStore", () => {
     zaehlung.value.knotenarme ? zaehlung.value.knotenarme : []
   );
 
-  const getFahrbeziehungen = computed(() =>
-    zaehlung.value.fahrbeziehungen ? zaehlung.value.fahrbeziehungen : []
+  const getVerkehrsbeziehungen = computed(() =>
+    zaehlung.value.verkehrsbeziehungen ? zaehlung.value.verkehrsbeziehungen : []
   );
 
   const getKategorien = computed(() =>
@@ -109,114 +109,114 @@ export const useZaehlungStore = defineStore("zaehlungStore", () => {
     zaehlung.value.kategorien = [];
   }
 
-  function addAllFahrbeziehungen(payload: Array<FahrbeziehungDTO>) {
-    zaehlung.value.fahrbeziehungen = [];
-    payload.forEach((fahrbeziehungDTO: FahrbeziehungDTO) => {
-      zaehlung.value.fahrbeziehungen.push(fahrbeziehungDTO);
+  function addAllVerkehrsbeziehungen(payload: Array<VerkehrsbeziehungDTO>) {
+    zaehlung.value.verkehrsbeziehungen = [];
+    payload.forEach((verkehrsbeziehungDTO: VerkehrsbeziehungDTO) => {
+      zaehlung.value.verkehrsbeziehungen.push(verkehrsbeziehungDTO);
     });
   }
 
-  function deleteFahrbeziehungByKnotenarmnummer(payload: number) {
-    const toDelete: Array<FahrbeziehungDTO> = [];
-    // Alle zu löschenden Fahrbeziehungen entfernen
-    zaehlung.value.fahrbeziehungen.forEach((fz: FahrbeziehungDTO) => {
-      // Vom Knotenarm ausgehende Fahrbeziehungen heraussuchen
+  function deleteVerkehrsbeziehungByKnotenarmnummer(payload: number) {
+    const toDelete: Array<VerkehrsbeziehungDTO> = [];
+    // Alle zu löschenden Verkehrsbeziehungen entfernen
+    zaehlung.value.verkehrsbeziehungen.forEach((fz: VerkehrsbeziehungDTO) => {
+      // Vom Knotenarm ausgehende Verkehrsbeziehungen heraussuchen
       if (fz.von === payload) {
         toDelete.push(fz);
       }
-      // In den Knotenarm eingehende Fahrbeziehungen heraussuchen
+      // In den Knotenarm eingehende Verkehrsbeziehungen heraussuchen
       // U-Turn wird oben schon entfernt
       if (fz.von !== fz.nach && fz.nach === payload) {
         toDelete.push(fz);
       }
     });
-    // Alle gefundenen Fahrbeziehungen entfernen
-    toDelete.forEach((deleteMe: FahrbeziehungDTO) => {
-      const index: number = zaehlung.value.fahrbeziehungen.indexOf(deleteMe);
+    // Alle gefundenen Verkehrsbeziehungen entfernen
+    toDelete.forEach((deleteMe: VerkehrsbeziehungDTO) => {
+      const index: number = zaehlung.value.verkehrsbeziehungen.indexOf(deleteMe);
       if (index > -1) {
-        zaehlung.value.fahrbeziehungen.splice(index, 1);
+        zaehlung.value.verkehrsbeziehungen.splice(index, 1);
       }
     });
   }
 
-  function updateFahrbeziehung(payload: FahrbeziehungDTO) {
-    let toUpdate: FahrbeziehungDTO | undefined = undefined;
+  function updateVerkehrsbeziehung(payload: VerkehrsbeziehungDTO) {
+    let toUpdate: VerkehrsbeziehungDTO | undefined = undefined;
     // Zu aktualisierendes Element suchen
-    zaehlung.value.fahrbeziehungen.forEach(
-      (fahrbeziehung: FahrbeziehungDTO) => {
+    zaehlung.value.verkehrsbeziehungen.forEach(
+      (verkehrsbeziehung: VerkehrsbeziehungDTO) => {
         if (
-          fahrbeziehung.von === payload.von &&
-          fahrbeziehung.nach === payload.nach
+            verkehrsbeziehung.von === payload.von &&
+            verkehrsbeziehung.nach === payload.nach
         ) {
-          toUpdate = fahrbeziehung;
+          toUpdate = verkehrsbeziehung;
         }
       }
     );
     // Wenn das Element existiert, wird dieses im Array durch das Aktualiserte ersetzt
     if (toUpdate) {
-      const index: number = zaehlung.value.fahrbeziehungen.indexOf(toUpdate);
+      const index: number = zaehlung.value.verkehrsbeziehungen.indexOf(toUpdate);
       if (index > -1) {
-        zaehlung.value.fahrbeziehungen[index] = payload;
+        zaehlung.value.verkehrsbeziehungen[index] = payload;
       }
     } else {
-      // Ansonsten wird eine neue Fahrbeziehung hinzugefügt
-      zaehlung.value.fahrbeziehungen.push(payload);
+      // Ansonsten wird eine neue Verkehrsbeziehung hinzugefügt
+      zaehlung.value.verkehrsbeziehungen.push(payload);
     }
   }
 
-  function deleteFahrbeziehung(payload: FahrbeziehungDTO) {
-    let toDelete: FahrbeziehungDTO | undefined = undefined;
-    // Alle zu löschenden Fahrbeziehungen entfernen
-    zaehlung.value.fahrbeziehungen.forEach((fz: FahrbeziehungDTO) => {
-      // Vom Knotenarm ausgehende Fahrbeziehungen heraussuchen
+  function deleteVerkehrsbeziehung(payload: VerkehrsbeziehungDTO) {
+    let toDelete: VerkehrsbeziehungDTO | undefined = undefined;
+    // Alle zu löschenden Verkehrsbeziehungen entfernen
+    zaehlung.value.verkehrsbeziehungen.forEach((fz: VerkehrsbeziehungDTO) => {
+      // Vom Knotenarm ausgehende Verkehrsbeziehungen heraussuchen
       if (fz.von === payload.von && fz.nach === payload.nach) {
         toDelete = fz;
       }
     });
     if (toDelete) {
-      const index: number = zaehlung.value.fahrbeziehungen.indexOf(toDelete);
+      const index: number = zaehlung.value.verkehrsbeziehungen.indexOf(toDelete);
       if (index > -1) {
-        zaehlung.value.fahrbeziehungen.splice(index, 1);
+        zaehlung.value.verkehrsbeziehungen.splice(index, 1);
       }
     }
   }
 
-  function deleteAllFahrbeziehungen() {
-    zaehlung.value.fahrbeziehungen = [];
+  function deleteAllVerkehrsbeziehungen() {
+    zaehlung.value.verkehrsbeziehungen = [];
   }
 
-  function updateFahrbeziehungKreisverkehr(payload: FahrbeziehungDTO) {
-    let toUpdate: FahrbeziehungDTO | undefined = undefined;
+  function updateVerkehrsbeziehungKreisverkehr(payload: VerkehrsbeziehungDTO) {
+    let toUpdate: VerkehrsbeziehungDTO | undefined = undefined;
     // Zu aktualisierendes Element suchen
-    zaehlung.value.fahrbeziehungen.forEach(
-      (fahrbeziehung: FahrbeziehungDTO) => {
+    zaehlung.value.verkehrsbeziehungen.forEach(
+      (verkehrsbeziehung: VerkehrsbeziehungDTO) => {
         if (
-          fahrbeziehung.knotenarm === payload.knotenarm &&
-          fahrbeziehung.heraus === payload.heraus &&
-          fahrbeziehung.hinein === payload.hinein &&
-          fahrbeziehung.vorbei === payload.vorbei
+            verkehrsbeziehung.knotenarm === payload.knotenarm &&
+            verkehrsbeziehung.heraus === payload.heraus &&
+            verkehrsbeziehung.hinein === payload.hinein &&
+            verkehrsbeziehung.vorbei === payload.vorbei
         ) {
-          toUpdate = fahrbeziehung;
+          toUpdate = verkehrsbeziehung;
         }
       }
     );
     // Wenn das Element existiert, wird dieses im Array durch das Aktualiserte ersetzt
     if (toUpdate) {
-      const index: number = zaehlung.value.fahrbeziehungen.indexOf(toUpdate);
+      const index: number = zaehlung.value.verkehrsbeziehungen.indexOf(toUpdate);
       if (index > -1) {
-        zaehlung.value.fahrbeziehungen[index] = payload;
+        zaehlung.value.verkehrsbeziehungen[index] = payload;
       }
     } else {
-      // Ansonsten wird eine neue Fahrbeziehung hinzugefügt
-      zaehlung.value.fahrbeziehungen.push(payload);
+      // Ansonsten wird eine neue Verkehrsbeziehung hinzugefügt
+      zaehlung.value.verkehrsbeziehungen.push(payload);
     }
   }
 
-  function deleteFahrbeziehungKreisverkehr(payload: FahrbeziehungDTO) {
-    let toDelete: FahrbeziehungDTO | undefined = undefined;
-    // Alle zu löschenden Fahrbeziehungen entfernen
-    zaehlung.value.fahrbeziehungen.forEach((fz: FahrbeziehungDTO) => {
-      // Vom Knotenarm ausgehende Fahrbeziehungen heraussuchen
+  function deleteVerkehrsbeziehungKreisverkehr(payload: VerkehrsbeziehungDTO) {
+    let toDelete: VerkehrsbeziehungDTO | undefined = undefined;
+    // Alle zu löschenden Verkehrsbeziehungen entfernen
+    zaehlung.value.verkehrsbeziehungen.forEach((fz: VerkehrsbeziehungDTO) => {
+      // Vom Knotenarm ausgehende Verkehrsbeziehungen heraussuchen
       if (
         fz.knotenarm === payload.knotenarm &&
         fz.heraus === payload.heraus &&
@@ -227,9 +227,9 @@ export const useZaehlungStore = defineStore("zaehlungStore", () => {
       }
     });
     if (toDelete) {
-      const index: number = zaehlung.value.fahrbeziehungen.indexOf(toDelete);
+      const index: number = zaehlung.value.verkehrsbeziehungen.indexOf(toDelete);
       if (index > -1) {
-        zaehlung.value.fahrbeziehungen.splice(index, 1);
+        zaehlung.value.verkehrsbeziehungen.splice(index, 1);
       }
     }
   }
@@ -239,7 +239,7 @@ export const useZaehlungStore = defineStore("zaehlungStore", () => {
     isHochrechnungsfaktorEditable,
     isZaehlungEditable,
     getKnotenarme,
-    getFahrbeziehungen,
+    getVerkehrsbeziehungen,
     getKategorien,
     setZaehlung,
     setKnotenarme,
@@ -250,12 +250,12 @@ export const useZaehlungStore = defineStore("zaehlungStore", () => {
     deleteKategorie,
     addAllKategorien,
     deleteAllKategorien,
-    addAllFahrbeziehungen,
-    deleteFahrbeziehungByKnotenarmnummer,
-    updateFahrbeziehung,
-    deleteFahrbeziehung,
-    deleteAllFahrbeziehungen,
-    updateFahrbeziehungKreisverkehr,
-    deleteFahrbeziehungKreisverkehr,
+    addAllVerkehrsbeziehungen,
+    deleteVerkehrsbeziehungByKnotenarmnummer,
+    updateVerkehrsbeziehung,
+    deleteVerkehrsbeziehung,
+    deleteAllVerkehrsbeziehungen,
+    updateVerkehrsbeziehungKreisverkehr,
+    deleteVerkehrsbeziehungKreisverkehr,
   };
 });

--- a/frontend/src/types/enum/Bewegungsrichtung.ts
+++ b/frontend/src/types/enum/Bewegungsrichtung.ts
@@ -1,0 +1,22 @@
+enum Bewegungsrichtung {
+    EIN = "EIN",
+    AUS = "AUS",
+}
+
+export default Bewegungsrichtung;
+
+export const himmelsRichtungenTextLong: Map<string, string> = new Map<
+    string,
+    string
+>([
+    [Bewegungsrichtung.EIN, "Ein"],
+    [Bewegungsrichtung.AUS, "Aus"],
+]);
+
+export const himmelsRichtungenTextShort: Map<string, string> = new Map<
+    string,
+    string
+>([
+    [Bewegungsrichtung.EIN, "Ein"],
+    [Bewegungsrichtung.AUS, "Aus"],
+]);

--- a/frontend/src/types/enum/Himmelsrichtung.ts
+++ b/frontend/src/types/enum/Himmelsrichtung.ts
@@ -35,6 +35,6 @@ export const himmelsRichtungenTextShort: Map<string, string> = new Map<
     [Himmelsrichtung.SO, "SO"],
     [Himmelsrichtung.S, "S"],
     [Himmelsrichtung.SW, "SW"],
-    [Himmelsrichtung.W, "W,"],
+    [Himmelsrichtung.W, "W"],
     [Himmelsrichtung.NW, "NW"],
 ]);

--- a/frontend/src/types/enum/Himmelsrichtung.ts
+++ b/frontend/src/types/enum/Himmelsrichtung.ts
@@ -1,0 +1,40 @@
+enum Himmelsrichtung {
+    N = "N",
+    NO = "NO",
+    O = "O",
+    SO = "SO",
+    S = "S",
+    SW = "SW",
+    W = "W",
+    NW = "NW",
+}
+
+export default Himmelsrichtung;
+
+export const himmelsRichtungenTextLong: Map<string, string> = new Map<
+    string,
+    string
+>([
+    [Himmelsrichtung.N, "Nord"],
+    [Himmelsrichtung.NO, "Nordost"],
+    [Himmelsrichtung.O, "Ost"],
+    [Himmelsrichtung.SO, "Südost"],
+    [Himmelsrichtung.S, "Süd"],
+    [Himmelsrichtung.SW, "Südwest"],
+    [Himmelsrichtung.W, "West"],
+    [Himmelsrichtung.NW, "Nordwest"],
+]);
+
+export const himmelsRichtungenTextShort: Map<string, string> = new Map<
+    string,
+    string
+>([
+    [Himmelsrichtung.N, "N"],
+    [Himmelsrichtung.NO, "NO"],
+    [Himmelsrichtung.O, "O"],
+    [Himmelsrichtung.SO, "SO"],
+    [Himmelsrichtung.S, "S"],
+    [Himmelsrichtung.SW, "SW"],
+    [Himmelsrichtung.W, "W,"],
+    [Himmelsrichtung.NW, "NW"],
+]);

--- a/frontend/src/types/zaehlung/LaengsverkehrDTO.ts
+++ b/frontend/src/types/zaehlung/LaengsverkehrDTO.ts
@@ -1,0 +1,11 @@
+import type BaseEntity from "@/types/common/BaseEntity";
+import type Bewegungsrichtung from "@/types/enum/Bewegungsrichtung";
+import type Himmelsrichtung from "@/types/enum/Himmelsrichtung";
+
+export default interface LaengsverkehrDTO extends BaseEntity {
+    knotenarm: number;
+
+    richtung: Bewegungsrichtung;
+
+    strassenseite: Himmelsrichtung;
+}

--- a/frontend/src/types/zaehlung/QuerungsverkehrDTO.ts
+++ b/frontend/src/types/zaehlung/QuerungsverkehrDTO.ts
@@ -1,0 +1,8 @@
+import type BaseEntity from "@/types/common/BaseEntity";
+import type Himmelsrichtung from "@/types/enum/Himmelsrichtung";
+
+export default interface QuerungsverkehrDTO extends BaseEntity {
+    knotenarm: number;
+
+    richtung: Himmelsrichtung;
+}

--- a/frontend/src/types/zaehlung/ZaehlungDTO.ts
+++ b/frontend/src/types/zaehlung/ZaehlungDTO.ts
@@ -1,4 +1,4 @@
-import type FahrbeziehungDTO from "@/domain/dto/FahrbeziehungDTO";
+import type VerkehrsbeziehungDTO from "@/domain/dto/VerkehrsbeziehungDTO";
 import type GeoPoint from "@/domain/GeoPoint";
 import type BaseEntity from "@/types/common/BaseEntity";
 import type KnotenarmDTO from "@/types/zaehlung/KnotenarmDTO";
@@ -28,7 +28,7 @@ export default interface ZaehlungDTO extends BaseEntity {
   zaehldauer: Zaehldauer;
   kommentar: string;
   knotenarme: KnotenarmDTO[];
-  fahrbeziehungen: FahrbeziehungDTO[];
+  verkehrsbeziehungen: VerkehrsbeziehungDTO[];
   // Zaehlstelle
   zaehlstelleNummer: string;
   zaehlstelleStadtbezirk: string;

--- a/frontend/src/util/VerkehrsbeziehungComparator.ts
+++ b/frontend/src/util/VerkehrsbeziehungComparator.ts
@@ -1,6 +1,6 @@
-import type FahrbeziehungDTO from "@/domain/dto/FahrbeziehungDTO";
+import type VerkehrsbeziehungDTO from "@/domain/dto/VerkehrsbeziehungDTO";
 
-export default class FahrbeziehungComparator {
+export default class VerkehrsbeziehungComparator {
   /**
    * Sortiert eine Liste von Knotenarmen nach der Nummer
    *
@@ -8,8 +8,8 @@ export default class FahrbeziehungComparator {
    * @param b
    */
   public static sortByActiveVonAndNach(
-    a: FahrbeziehungDTO,
-    b: FahrbeziehungDTO
+    a: VerkehrsbeziehungDTO,
+    b: VerkehrsbeziehungDTO
   ): number {
     // beide sind aktiv, dann nach von und dann nach nach
     if (a.active && b.active) {


### PR DESCRIPTION
# Description

Für die Zählarten FJS, QU und QJS können nun die Verkehrsbeziehungn, Laengsverkehre und Querverkehre gespeichert werden. Des Weiteren wurde Entität Fahrbeziehung nach Verkehrsbeziehung umbenannt.

# Issue References

FV-105
 
# Definition of Done

<!-- Check all completed DoD requirements here -->

- [ ] Acceptance criteria are met
- [ ] Testing is done (unit-tests, DEV-environment)
- [ ] Build/Test workflow has successfully finished
- [ ] Release notes are complemented
- [ ] Documentation is complemented (operator manual, system specification, etc.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added compass-based directions and inbound/outbound labels, plus new longitudinal and crossing traffic types for richer traffic classification.

* **Refactor**
  * Unified traffic-relationship terminology across the app for clearer, more consistent handling and user-facing messaging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->