### PR TITLE
FV-241 bei CSV-Validierung für QjS muss das Feld "nach" befüllt werden

### DIFF
--- a/frontend/src/components/zaehlung/form/KnotenLageForm.vue
+++ b/frontend/src/components/zaehlung/form/KnotenLageForm.vue
@@ -519,9 +519,19 @@ function checkFussverkehrData(
   splittedLine: Array<string>
 ): string {
   const zaehlart = zaehlung.value.zaehlart;
-  if (splittedLine[1].trim()) {
-    return "Zielknotenarm darf nicht gefüllt sein.";
+
+  // Prüfung des Zielknotenarms (nach)
+  if (
+    [Zaehlart.FJS, Zaehlart.QU].includes(zaehlart) &&
+    splittedLine[1].trim()
+  ) {
+    return "Zielknotenarm (nach) darf nicht gefüllt sein.";
   }
+  if (zaehlart === Zaehlart.QJS && isEmpty(splittedLine[1])) {
+    return "Zielknotenarm (nach) darf nicht leer sein.";
+  }
+
+  // Prüfung der Strassenseite
   if (
     [Zaehlart.FJS, Zaehlart.QJS].includes(zaehlart) &&
     isEmpty(splittedLine[2])
@@ -531,13 +541,10 @@ function checkFussverkehrData(
   if (zaehlart === Zaehlart.QU && splittedLine[2].trim()) {
     return "Strassenseite muss leer sein.";
   }
-
-  // Prüfung der Strassenseite
   if (zaehlart === Zaehlart.FJS || zaehlart === Zaehlart.QJS) {
     if (!StrassenseiteText.has(splittedLine[2].trim())) {
       return `Strassenseite ist ungültig: ${splittedLine[2]}.`;
     }
-
     if (
       isArmnummerAndStrassenseiteInvalid(
         splittedLine[2],
@@ -568,6 +575,7 @@ function checkFussverkehrData(
     }
   }
 
+  // Prüfung der Richtung
   if (zaehlart === Zaehlart.QU) {
     if (
       ![

--- a/frontend/src/components/zaehlung/form/KnotenLageForm.vue
+++ b/frontend/src/components/zaehlung/form/KnotenLageForm.vue
@@ -527,7 +527,7 @@ function checkFussverkehrData(
   ) {
     return "Zielknotenarm (nach) darf nicht gefüllt sein.";
   }
-  if (zaehlart === Zaehlart.QJS && isEmpty(splittedLine[1])) {
+  if (zaehlart === Zaehlart.QJS && !splittedLine[1].trim()) {
     return "Zielknotenarm (nach) darf nicht leer sein.";
   }
 


### PR DESCRIPTION
# Description

<!-- Add a short description of what the request is all about here -->
validation of "nach"-column added

# Issue References

<!-- Add the corresponding issues here -->
FV-241
 
# Definition of Done

<!-- Check all completed DoD requirements here -->

- [x] Acceptance criteria are met
- [ ] Testing is done (unit-tests, DEV-environment)
- [ ] Build/Test workflow has successfully finished
- [ ] Release notes are complemented
- [ ] Documentation is complemented (operator manual, system specification, etc.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for pedestrian-count entries with stricter rules per counting type (FJS, QJS, QU).
  * Zielknotenarm (nach) now enforced: forbidden in some cases, required for QJS.
  * Strassenseite validation tightened; QU now requires empty value, others validated against allowed values.
  * Direction validation added and adjusted: broader for QU, EIN/AUS for FJS, empty for QJS.
  * Error messages refined for clearer guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->