### PR TITLE
FV-295 Entfall der Anzeige für Verkehrsbeziehungen im Reiter Knoten & Lage

### DIFF
--- a/frontend/src/components/zaehlung/form/KnotenLageForm.vue
+++ b/frontend/src/components/zaehlung/form/KnotenLageForm.vue
@@ -130,7 +130,7 @@
           sm="2"
         >
           <v-data-table
-            v-if="isNotZaehlartFjsOrQu && isNotKreisverkehr"
+            v-if="isNotKreisverkehr && isNotZaehlartFjsOrQu"
             density="compact"
             :headers="verkehrsbeziehungHeader as Array<any>"
             :items="allVerkehrsbeziehungen"

--- a/frontend/src/components/zaehlung/form/KnotenLageForm.vue
+++ b/frontend/src/components/zaehlung/form/KnotenLageForm.vue
@@ -130,7 +130,7 @@
           sm="2"
         >
           <v-data-table
-            v-if="isNotKreisverkehr"
+            v-if="isNotZaehlartFjsOrQu && isNotKreisverkehr"
             density="compact"
             :headers="verkehrsbeziehungHeader as Array<any>"
             :items="allVerkehrsbeziehungen"
@@ -237,6 +237,13 @@ const allVerkehrsbeziehungen = computed<Array<VerkehrsbeziehungDTO>>(() =>
 );
 
 const isNotKreisverkehr = computed<boolean>(() => !zaehlung.value.kreisverkehr);
+
+const isNotZaehlartFjsOrQu = computed<boolean>(() => {
+  return !(
+    zaehlung.value.zaehlart === Zaehlart.FJS ||
+    zaehlung.value.zaehlart === Zaehlart.QU
+  );
+});
 
 const verkehrsbeziehungHeader = [
   {


### PR DESCRIPTION
# Description

Entfall der Anzeige für Verkehrsbeziehungen im Reiter "Knoten & Lage".

# Issue References

<!-- Add the corresponding issues here -->
 
# Definition of Done

<!-- Check all completed DoD requirements here -->

- [ ] Acceptance criteria are met
- [ ] Testing is done (unit-tests, DEV-environment)
- [ ] Build/Test workflow has successfully finished
- [ ] Release notes are complemented
- [ ] Documentation is complemented (operator manual, system specification, etc.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed form behavior to hide data tables when using specific counting methods (in addition to existing roundabout conditions), ensuring users see only relevant form fields for their selected option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->